### PR TITLE
Switch to OMPL version 1.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ The Experience based planning update to the coordination framework allows for st
 * The RViz visualization has been fixed to show the map published on the /map topic
 * A graph visualization tool has been developed to display the experiences stored in the databases
 
+### Dependencies:
+* **OMPL 1.4.2** - Installation instructions can be found <a href="http://ompl.kavrakilab.org/installation.html">here</a>. Generation of python bindings takes a lot of time (several hours). Since we do not need python bindings, install OMPL without bindings for faster build.
+
 ### Usage:
 * Clone this repository
 ```

--- a/SimpleReedsSheppCarPlanner/CMakeLists.txt
+++ b/SimpleReedsSheppCarPlanner/CMakeLists.txt
@@ -8,14 +8,14 @@ SET(CMAKE_SHARED_LINKER_FLAGS "-m64")
 project (simplereedssheppcarplanner)
 
 #Depends on OMPL and MRPT
-find_package(OMPL)
+# find_package(OMPL)
 find_package(MRPT) 
-include_directories( ${OMPL_INCLUDE_DIRS} )
+include_directories( /usr/local/include/ )
 include_directories( ${MRPT_INCLUDE_DIRS} )
 include_directories( src/include )
 file(GLOB SOURCES "src/*.cpp")
 add_library(simplereedssheppcarplanner SHARED ${SOURCES})
-target_link_libraries(simplereedssheppcarplanner ${OMPL_LIBRARIES} ${MRPT_LIBRARIES})
+target_link_libraries(simplereedssheppcarplanner /usr/local/lib/libompl.so ${MRPT_LIBRARIES})
 
 #Use "sudo make install" to apply
 install(TARGETS simplereedssheppcarplanner DESTINATION /usr/local/lib)

--- a/graphml_generator/CMakeLists.txt
+++ b/graphml_generator/CMakeLists.txt
@@ -7,7 +7,7 @@ project (Generate_Graphml)
 set (CMAKE_CXX_STANDARD 11)
 
 find_package(Boost COMPONENTS system filesystem serialization REQUIRED)
-find_package(OMPL)
+# find_package(OMPL)
 find_package(MRPT) 
 
 # Define a variable PROJECT_LINK_LIBS to contain all library dependencies
@@ -19,6 +19,7 @@ link_directories(/usr/local/lib/)
 # Define the paths to the include directories
 include_directories(include/
  /usr/include/eigen3/
+ /usr/local/include/
  )
 
  include_directories( ${MRPT_INCLUDE_DIRS} )
@@ -29,4 +30,4 @@ add_executable(GenerateGraphml
  )
 
 # Link the executable to the defined libraries
-target_link_libraries(GenerateGraphml ${PROJECT_LINK_LIBS} ${OMPL_LIBRARIES} ${MRPT_LIBRARIES})
+target_link_libraries(GenerateGraphml ${PROJECT_LINK_LIBS} /usr/local/lib/libompl.so ${MRPT_LIBRARIES})


### PR DESCRIPTION
This pull request solves the issue #6. We will now use the OMPL version 1.4.2 for Lightning and Thunder experience based planners.