### PR TITLE
Support for variable number of iterations in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ git checkout ExperinceBasedPlanning
 ```
 ./gradlew run -Pdemo=customTests.University
 ```
+or to specify number of simulation iterations (for example 2 itertions) as well, use:
+```
+./gradlew run -Pdemo=customTests.University -Pitr=2
+```
 * Visualization medium depends the test case. Tests based on JAVA Swing will automatically launch the visualization. For browser based visualization, open the link <a href="http://localhost:8080">http://localhost:8080</a>. For RViz visualization (which is used for all newly added tests) start RViz with the custom generated RViz config file after launching the test case using the below command:
 ```
 rosrun rviz rviz -d ~/config.rviz

--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,11 @@ dependencies {
 
 run {
     if (project.hasProperty("demo")) {
-        args(demo)
+        if (project.hasProperty("itr")) {
+            args(demo, itr)
+        }
+        else {
+            args(demo)
+        }
     }
 }

--- a/src/main/java/se/oru/coordination/coordination_oru/demo/DemoLauncher.java
+++ b/src/main/java/se/oru/coordination/coordination_oru/demo/DemoLauncher.java
@@ -23,7 +23,7 @@ public class DemoLauncher {
 	
 	private static void printUsage() {
 
-		System.out.println("Usage: ./gradlew run -Pdemo=<demo>\n\nAvailable options for <demo>");
+        System.out.println("Usage: \n./gradlew run -Pdemo=<demo> \n\tOR \n./gradlew run -Pdemo=<demo> -Pitr=N \n\nN represents the number of simulation iterations.\nAvailable options for <demo>");
 
 		List<ClassLoader> classLoadersList = new LinkedList<ClassLoader>();
 		classLoadersList.add(ClasspathHelper.contextClassLoader());
@@ -64,14 +64,19 @@ public class DemoLauncher {
 		
 		//Forces to loads the class so that license and (c) are printed even if no demo is invoked
 		Class.forName("se.oru.coordination.coordination_oru.TrajectoryEnvelopeCoordinator");
-		
-		if (args.length != 1) printUsage();
+
+		if (args.length < 1 || args.length > 2) printUsage();
 		else {
 			String className = args[0];
 			try {
 				Class<?> cl = Class.forName(testsPackage+"."+className);
 				Method meth = cl.getMethod("main", String[].class);
-			    String[] params = null;
+                String[] params = null;
+                if (args.length == 2)
+                {
+                    params = new String[1];
+                    params[0] = args[1];
+                }
 			    meth.invoke(null, (Object) params);
 			}
 			catch (IllegalAccessException e) { e.printStackTrace(); }

--- a/src/main/java/se/oru/coordination/coordination_oru/tests/customTests/NarrowCorridor.java
+++ b/src/main/java/se/oru/coordination/coordination_oru/tests/customTests/NarrowCorridor.java
@@ -63,7 +63,9 @@ public class NarrowCorridor {
 
 		double MAX_ACCEL = 3.0;
 		double MAX_VEL = 14.0;
-		int CONTROL_PERIOD = 1000;
+        int CONTROL_PERIOD = 1000;
+
+        final int numOfSimulationIterations = (args != null) ? Integer.parseInt(args[0]) : 20;
 		//Instantiate a trajectory envelope coordinator.
 		//The TrajectoryEnvelopeCoordinatorSimulation implementation provides
 		// -- the factory method getNewTracker() which returns a trajectory envelope tracker
@@ -182,9 +184,11 @@ public class NarrowCorridor {
 			}
 			
 			Mission m = new Mission(robotID, path, startLocName, endLocName, Missions.getLocation(startLocName), Missions.getLocation(endLocName));
-			Missions.enqueueMission(m);
-			Mission m1 = new Mission(robotID, pathInv, endLocName, startLocName, Missions.getLocation(endLocName), Missions.getLocation(startLocName));
-			Missions.enqueueMission(m1);
+            Missions.enqueueMission(m);
+            if (numOfSimulationIterations > 1) {
+                Mission m1 = new Mission(robotID, pathInv, endLocName, startLocName, Missions.getLocation(endLocName), Missions.getLocation(startLocName));
+                Missions.enqueueMission(m1);
+            }
 		}
 
 		System.out.println("Added missions " + Missions.getMissions());
@@ -210,8 +214,8 @@ public class NarrowCorridor {
 				public void run() {
 					boolean firstTime = true;
 					int sequenceNumber = 0;
-					int totalIterations = 20;
-					if (robotID%2 == 0) totalIterations = 19;
+					int totalIterations = numOfSimulationIterations;
+					// if (robotID%2 == 0 && numOfSimulationIterations > 1) totalIterations = numOfSimulationIterations -1;
 					String lastDestination = "R_"+(robotID-1);
 					long startTime = Calendar.getInstance().getTimeInMillis();
 					while (true && totalIterations > 0) {

--- a/src/main/java/se/oru/coordination/coordination_oru/tests/customTests/University.java
+++ b/src/main/java/se/oru/coordination/coordination_oru/tests/customTests/University.java
@@ -65,6 +65,8 @@ public class University {
 		double MAX_ACCEL = 3.0;
 		double MAX_VEL = 14.0;
 		int CONTROL_PERIOD = 1000;
+
+        final int numOfSimulationIterations = (args != null) ? Integer.parseInt(args[0]) : 20;
 		//Instantiate a trajectory envelope coordinator.
 		//The TrajectoryEnvelopeCoordinatorSimulation implementation provides
 		// -- the factory method getNewTracker() which returns a trajectory envelope tracker
@@ -200,9 +202,13 @@ public class University {
 			}
 			
 			Mission m = new Mission(robotID, path, startLocName, endLocName, Missions.getLocation(startLocName), Missions.getLocation(endLocName));
-			Missions.enqueueMission(m);
-			Mission m1 = new Mission(robotID, pathInv, endLocName, startLocName, Missions.getLocation(endLocName), Missions.getLocation(startLocName));
-			Missions.enqueueMission(m1);
+            Missions.enqueueMission(m);
+            if (numOfSimulationIterations > 1)
+            {
+                // Add the reverse path as mission
+                Mission m1 = new Mission(robotID, pathInv, endLocName, startLocName, Missions.getLocation(endLocName), Missions.getLocation(startLocName));
+                Missions.enqueueMission(m1);
+            }
 		}
 
 		System.out.println("Added missions " + Missions.getMissions());
@@ -228,8 +234,8 @@ public class University {
 				public void run() {
 					boolean firstTime = true;
 					int sequenceNumber = 0;
-					int totalIterations = 20;
-					if (robotID%2 == 0) totalIterations = 19;
+					int totalIterations = numOfSimulationIterations;
+					// if (robotID%2 == 0 && numOfSimulationIterations > 1) totalIterations = numOfSimulationIterations -1;
 					String lastDestination = "R_"+(robotID-1);
 					long startTime = Calendar.getInstance().getTimeInMillis();
 					while (true && totalIterations > 0) {


### PR DESCRIPTION
We can now use the gradle property `itr` to specify the number of iterations that the robots should execute.

Start the test as
```
./gradlew run -Pdemo=customTests.University -Pitr=N
```

where `N` is the number of iterations and must have an integer value