### PR TITLE
Support force use rrt connect planner when replanning

### DIFF
--- a/SimpleReedsSheppCarPlanner/src/MultipleCircleReedsSheppCarPlanner.cpp
+++ b/SimpleReedsSheppCarPlanner/src/MultipleCircleReedsSheppCarPlanner.cpp
@@ -73,9 +73,9 @@ plan_multiple_circles(const char *mapFilename, double mapResolution,
                       double startTheta, double goalX, double goalY,
                       double goalTheta, PathPose **path, int *pathLength,
                       double distanceBetweenPathPoints, double turningRadius,
-                      PLANNER_TYPE plannerType, const char *experienceDBName)
+                      PLANNER_TYPE plannerType, const char *experienceDBName,
+                      bool forceUseRRTConnect)
 {
-
     double pLen = 0.0;
     int numInterpolationPoints = 0;
     ob::StateSpacePtr space(new ob::ReedsSheppStateSpace(turningRadius));
@@ -106,15 +106,22 @@ plan_multiple_circles(const char *mapFilename, double mapResolution,
                                                robotRadius, xCoords, yCoords,
                                                numCoords)));
 
-     ob::PlannerPtr planner(new og::RRTConnect(si));
-    //ob::PlannerPtr planner(new og::RRTstar(si));
-    // ob::PlannerPtr planner(new og::TRRT(si));
-    // ob::PlannerPtr planner(new og::SST(si));
-    // ob::PlannerPtr planner(new og::LBTRRT(si));
-    // ob::PlannerPtr planner(new og::PRMstar(si));
-    // ob::PlannerPtr planner(new og::SPARS(si));
-    // ob::PlannerPtr planner(new og::pRRT(si));
-    // ob::PlannerPtr planner(new og::LazyRRT(si));
+    ob::PlannerPtr planner;
+    if (forceUseRRTConnect) {
+        planner = ob::PlannerPtr(new og::RRTConnect(si));
+    }
+    else {
+        // planner = ob::PlannerPtr(new og::RRTConnect(si));
+        planner = ob::PlannerPtr(new og::RRTstar(si));
+        // planner = ob::PlannerPtr(new og::TRRT(si));
+        // planner = ob::PlannerPtr(new og::SST(si));
+        // planner = ob::PlannerPtr(new og::LBTRRT(si));
+        // planner = ob::PlannerPtr(new og::PRMstar(si));
+        // planner = ob::PlannerPtr(new og::SPARS(si));
+        // planner = ob::PlannerPtr(new og::pRRT(si));
+        // planner = ob::PlannerPtr(new og::LazyRRT(si));
+    }
+
     ssPtr->setPlanner(planner);
 
     ompl::tools::ExperienceSetup *ePtr =
@@ -181,13 +188,12 @@ plan_multiple_circles(const char *mapFilename, double mapResolution,
     return solved ? 1 : 0;
 }
 
-extern "C" bool
-plan_multiple_circles_nomap(double *xCoords, double *yCoords, int numCoords,
-                            double startX, double startY, double startTheta,
-                            double goalX, double goalY, double goalTheta,
-                            PathPose **path, int *pathLength,
-                            double distanceBetweenPathPoints,
-                            double turningRadius, PLANNER_TYPE plannerType)
+extern "C" bool plan_multiple_circles_nomap(
+    double *xCoords, double *yCoords, int numCoords, double startX,
+    double startY, double startTheta, double goalX, double goalY,
+    double goalTheta, PathPose **path, int *pathLength,
+    double distanceBetweenPathPoints, double turningRadius,
+    PLANNER_TYPE plannerType, bool forceUseRRTConnect)
 {
 
     double pLen = 0.0;
@@ -215,15 +221,21 @@ plan_multiple_circles_nomap(double *xCoords, double *yCoords, int numCoords,
     si->setStateValidityChecker(ob::StateValidityCheckerPtr(
         new MultipleCircleStateValidityChecker(si)));
 
-     ob::PlannerPtr planner(new og::RRTConnect(si));
-    //ob::PlannerPtr planner(new og::RRTstar(si));
-    // ob::PlannerPtr planner(new og::TRRT(si));
-    // ob::PlannerPtr planner(new og::SST(si));
-    // ob::PlannerPtr planner(new og::LBTRRT(si));
-    // ob::PlannerPtr planner(new og::PRMstar(si));
-    // ob::PlannerPtr planner(new og::SPARS(si));
-    // ob::PlannerPtr planner(new og::pRRT(si));
-    // ob::PlannerPtr planner(new og::LazyRRT(si));
+    ob::PlannerPtr planner;
+    if (forceUseRRTConnect) {
+        planner = ob::PlannerPtr(new og::RRTConnect(si));
+    }
+    else {
+        // planner = ob::PlannerPtr(new og::RRTConnect(si));
+        planner = ob::PlannerPtr(new og::RRTstar(si));
+        // planner = ob::PlannerPtr(new og::TRRT(si));
+        // planner = ob::PlannerPtr(new og::SST(si));
+        // planner = ob::PlannerPtr(new og::LBTRRT(si));
+        // planner = ob::PlannerPtr(new og::PRMstar(si));
+        // planner = ob::PlannerPtr(new og::SPARS(si));
+        // planner = ob::PlannerPtr(new og::pRRT(si));
+        // planner = ob::PlannerPtr(new og::LazyRRT(si));
+    }
     ssPtr->setPlanner(planner);
 
     ompl::tools::ExperienceSetup *ePtr =

--- a/SimpleReedsSheppCarPlanner/src/MultipleCircleReedsSheppCarPlanner.cpp
+++ b/SimpleReedsSheppCarPlanner/src/MultipleCircleReedsSheppCarPlanner.cpp
@@ -129,6 +129,12 @@ plan_multiple_circles(const char *mapFilename, double mapResolution,
     if (ePtr != NULL) {
         ompl::base::PlannerPtr repairPlanner(new og::RRTConnect(si));
         ePtr->setRepairPlanner(repairPlanner);
+
+        // Disable planning from recall if we are replanning (i.e. RRTConnect
+        // planner is forced to be used)
+        if (forceUseRRTConnect) {
+            ePtr->enablePlanningFromRecall(false);
+        }
     }
 
     // set the start and goal states

--- a/SimpleReedsSheppCarPlanner/src/MultipleCircleReedsSheppCarPlanner.cpp
+++ b/SimpleReedsSheppCarPlanner/src/MultipleCircleReedsSheppCarPlanner.cpp
@@ -74,7 +74,7 @@ plan_multiple_circles(const char *mapFilename, double mapResolution,
                       double goalTheta, PathPose **path, int *pathLength,
                       double distanceBetweenPathPoints, double turningRadius,
                       PLANNER_TYPE plannerType, const char *experienceDBName,
-                      bool forceUseRRTConnect)
+                      bool isReplan)
 {
     double pLen = 0.0;
     int numInterpolationPoints = 0;
@@ -107,7 +107,7 @@ plan_multiple_circles(const char *mapFilename, double mapResolution,
                                                numCoords)));
 
     ob::PlannerPtr planner;
-    if (forceUseRRTConnect) {
+    if (isReplan) {
         planner = ob::PlannerPtr(new og::RRTConnect(si));
     }
     else {
@@ -130,9 +130,8 @@ plan_multiple_circles(const char *mapFilename, double mapResolution,
         ompl::base::PlannerPtr repairPlanner(new og::RRTConnect(si));
         ePtr->setRepairPlanner(repairPlanner);
 
-        // Disable planning from recall if we are replanning (i.e. RRTConnect
-        // planner is forced to be used)
-        if (forceUseRRTConnect) {
+        // Disable planning from recall if we are replanning
+        if (isReplan) {
             ePtr->enablePlanningFromRecall(false);
         }
     }
@@ -199,7 +198,7 @@ extern "C" bool plan_multiple_circles_nomap(
     double startY, double startTheta, double goalX, double goalY,
     double goalTheta, PathPose **path, int *pathLength,
     double distanceBetweenPathPoints, double turningRadius,
-    PLANNER_TYPE plannerType, bool forceUseRRTConnect)
+    PLANNER_TYPE plannerType, bool isReplan)
 {
 
     double pLen = 0.0;
@@ -228,7 +227,7 @@ extern "C" bool plan_multiple_circles_nomap(
         new MultipleCircleStateValidityChecker(si)));
 
     ob::PlannerPtr planner;
-    if (forceUseRRTConnect) {
+    if (isReplan) {
         planner = ob::PlannerPtr(new og::RRTConnect(si));
     }
     else {
@@ -249,6 +248,12 @@ extern "C" bool plan_multiple_circles_nomap(
     if (ePtr != NULL) {
         ompl::base::PlannerPtr repairPlanner(new og::RRTConnect(si));
         ePtr->setRepairPlanner(repairPlanner);
+
+        // Disable planning from recall if we are replanning (i.e. RRTConnect
+        // planner is forced to be used)
+        if (isReplan) {
+            ePtr->enablePlanningFromRecall(false);
+        }
     }
 
     // set the start and goal states

--- a/src/main/java/se/oru/coordination/coordination_oru/TrajectoryEnvelopeCoordinator.java
+++ b/src/main/java/se/oru/coordination/coordination_oru/TrajectoryEnvelopeCoordinator.java
@@ -952,9 +952,11 @@ public abstract class TrajectoryEnvelopeCoordinator {
 		mp.setStart(fromPose);
 		mp.setGoals(toPose);
 		mp.clearObstacles();
+        mp.setIsReplan(true);
 		if (obstaclesToConsider != null && obstaclesToConsider.length > 0) mp.addObstacles(obstaclesToConsider);
-		if (mp.plan()) return mp.getPath();
-		return null;
+        PoseSteering[] result = mp.plan() ? mp.getPath() : null;
+        mp.setIsReplan(false);
+		return result;
 	}
 	
 	protected void rePlanPath(HashSet<Integer> robotsToReplan, HashSet<Integer> allRobots) {

--- a/src/main/java/se/oru/coordination/coordination_oru/motionplanning/AbstractMotionPlanner.java
+++ b/src/main/java/se/oru/coordination/coordination_oru/motionplanning/AbstractMotionPlanner.java
@@ -39,6 +39,7 @@ public abstract class AbstractMotionPlanner {
 	protected ArrayList<Geometry> obstacles = new ArrayList<Geometry>();
 	protected Coordinate[] footprintCoords = null;
 	protected boolean verifyPlanning = true;
+    protected boolean isReplan = false;
 	
 	protected PoseSteering[] pathPS = null;
 
@@ -76,7 +77,15 @@ public abstract class AbstractMotionPlanner {
 
 	public void setMapResolution(double res) {
 		this.mapResolution = res;
-	}
+    }
+    
+    public void setIsReplan(boolean value) {
+        this.isReplan = value;
+    }
+
+    public boolean getIsRePlan() {
+        return this.isReplan;
+    }
 	
 	private synchronized void addObstaclesToMap() {
 		BufferedImage img = null;

--- a/src/main/java/se/oru/coordination/coordination_oru/motionplanning/ompl/ReedsSheppCarPlanner.java
+++ b/src/main/java/se/oru/coordination/coordination_oru/motionplanning/ompl/ReedsSheppCarPlanner.java
@@ -108,6 +108,8 @@ public class ReedsSheppCarPlanner extends AbstractMotionPlanner {
         ArrayList<PoseSteering> finalPath = new ArrayList<PoseSteering>();  
         PLANNER_TYPE plannerType = PLANNER_TYPE.LIGHTNING;
         String experienceDBName = this.getOriginalFilename();
+        // Use RRT Connect planner to accelerate replanning
+        boolean forUseRRTConnectPlanner = this.isReplan;
 		for (int i = 0; i < this.goal.length; i++) {
 			Pose start_ = null;
 			Pose goal_ = this.goal[i];
@@ -116,7 +118,10 @@ public class ReedsSheppCarPlanner extends AbstractMotionPlanner {
 			path = new PointerByReference();
 			pathLength = new IntByReference();
 			if (collisionCircleCenters == null) {
-				if (!INSTANCE.plan(mapFilename, mapResolution, robotRadius, start_.getX(), start_.getY(), start_.getTheta(), goal_.getX(), goal_.getY(), goal_.getTheta(), path, pathLength, distanceBetweenPathPoints, turningRadius)) return false;
+                if (!INSTANCE.plan(mapFilename, mapResolution, robotRadius,
+                     start_.getX(), start_.getY(), start_.getTheta(), goal_.getX(),
+                     goal_.getY(), goal_.getTheta(), path, pathLength, 
+                     distanceBetweenPathPoints, turningRadius)) return false;
 			}
 			else {
 				double[] xCoords = new double[collisionCircleCenters.length];
@@ -128,10 +133,18 @@ public class ReedsSheppCarPlanner extends AbstractMotionPlanner {
 				}
 				metaCSPLogger.info("Path planning with " + collisionCircleCenters.length + " circle positions");
 				if (this.mapFilename != null) {
-					if (!INSTANCE.plan_multiple_circles(mapFilename, mapResolution, robotRadius, xCoords, yCoords, numCoords, start_.getX(), start_.getY(), start_.getTheta(), goal_.getX(), goal_.getY(), goal_.getTheta(), path, pathLength, distanceBetweenPathPoints, turningRadius, plannerType.ordinal(), experienceDBName)) return false;					
+                    if (!INSTANCE.plan_multiple_circles(mapFilename, mapResolution,
+                        robotRadius, xCoords, yCoords, numCoords, start_.getX(),
+                        start_.getY(), start_.getTheta(), goal_.getX(), goal_.getY(),
+                        goal_.getTheta(), path, pathLength, distanceBetweenPathPoints,
+                        turningRadius, plannerType.ordinal(), experienceDBName,
+                        forUseRRTConnectPlanner)) return false;
 				}
 				else {
-					if (!INSTANCE.plan_multiple_circles_nomap(xCoords, yCoords, numCoords, start_.getX(), start_.getY(), start_.getTheta(), goal_.getX(), goal_.getY(), goal_.getTheta(), path, pathLength, distanceBetweenPathPoints, turningRadius, plannerType.ordinal())) return false;					
+                    if (!INSTANCE.plan_multiple_circles_nomap(xCoords, yCoords, numCoords,
+                        start_.getX(), start_.getY(), start_.getTheta(), goal_.getX(),
+                        goal_.getY(), goal_.getTheta(), path, pathLength, distanceBetweenPathPoints,
+                        turningRadius, plannerType.ordinal(), forUseRRTConnectPlanner)) return false;
 				}
 			}
 			final Pointer pathVals = path.getValue();

--- a/src/main/java/se/oru/coordination/coordination_oru/motionplanning/ompl/ReedsSheppCarPlanner.java
+++ b/src/main/java/se/oru/coordination/coordination_oru/motionplanning/ompl/ReedsSheppCarPlanner.java
@@ -108,8 +108,6 @@ public class ReedsSheppCarPlanner extends AbstractMotionPlanner {
         ArrayList<PoseSteering> finalPath = new ArrayList<PoseSteering>();  
         PLANNER_TYPE plannerType = PLANNER_TYPE.LIGHTNING;
         String experienceDBName = this.getOriginalFilename();
-        // Use RRT Connect planner to accelerate replanning
-        boolean forUseRRTConnectPlanner = this.isReplan;
 		for (int i = 0; i < this.goal.length; i++) {
 			Pose start_ = null;
 			Pose goal_ = this.goal[i];
@@ -138,13 +136,13 @@ public class ReedsSheppCarPlanner extends AbstractMotionPlanner {
                         start_.getY(), start_.getTheta(), goal_.getX(), goal_.getY(),
                         goal_.getTheta(), path, pathLength, distanceBetweenPathPoints,
                         turningRadius, plannerType.ordinal(), experienceDBName,
-                        forUseRRTConnectPlanner)) return false;
+                        this.isReplan)) return false;
 				}
 				else {
                     if (!INSTANCE.plan_multiple_circles_nomap(xCoords, yCoords, numCoords,
                         start_.getX(), start_.getY(), start_.getTheta(), goal_.getX(),
                         goal_.getY(), goal_.getTheta(), path, pathLength, distanceBetweenPathPoints,
-                        turningRadius, plannerType.ordinal(), forUseRRTConnectPlanner)) return false;
+                        turningRadius, plannerType.ordinal(), this.isReplan)) return false;
 				}
 			}
 			final Pointer pathVals = path.getValue();

--- a/src/main/java/se/oru/coordination/coordination_oru/motionplanning/ompl/ReedsSheppCarPlannerLib.java
+++ b/src/main/java/se/oru/coordination/coordination_oru/motionplanning/ompl/ReedsSheppCarPlannerLib.java
@@ -13,9 +13,9 @@ public interface ReedsSheppCarPlannerLib extends Library {
 	
 	public boolean plan(String mapFilename, double mapResolution, double robotRadius, double startX, double startY, double startTheta, double goalX, double goalY, double goalTheta, PointerByReference path, IntByReference pathLength, double distanceBetweenPathPoints, double turningRadius);
 
-	public boolean plan_multiple_circles(String mapFilename, double mapResolution, double robotRadius, double[] xCoords, double[] yCoords, int numCoords, double startX, double startY, double startTheta, double goalX, double goalY, double goalTheta, PointerByReference path, IntByReference pathLength, double distanceBetweenPathPoints, double turningRadius, int plannerType, String experienceDBName);
+	public boolean plan_multiple_circles(String mapFilename, double mapResolution, double robotRadius, double[] xCoords, double[] yCoords, int numCoords, double startX, double startY, double startTheta, double goalX, double goalY, double goalTheta, PointerByReference path, IntByReference pathLength, double distanceBetweenPathPoints, double turningRadius, int plannerType, String experienceDBName, boolean forceUseRRTConnect);
 	
-	public boolean plan_multiple_circles_nomap(double[] xCoords, double[] yCoords, int numCoords, double startX, double startY, double startTheta, double goalX, double goalY, double goalTheta, PointerByReference path, IntByReference pathLength, double distanceBetweenPathPoints, double turningRadius, int plannerType);
+	public boolean plan_multiple_circles_nomap(double[] xCoords, double[] yCoords, int numCoords, double startX, double startY, double startTheta, double goalX, double goalY, double goalTheta, PointerByReference path, IntByReference pathLength, double distanceBetweenPathPoints, double turningRadius, int plannerType, boolean forceUseRRTConnect);
 
 	public void cleanupPath(Pointer p);
 	

--- a/src/main/java/se/oru/coordination/coordination_oru/motionplanning/ompl/ReedsSheppCarPlannerLib.java
+++ b/src/main/java/se/oru/coordination/coordination_oru/motionplanning/ompl/ReedsSheppCarPlannerLib.java
@@ -13,9 +13,9 @@ public interface ReedsSheppCarPlannerLib extends Library {
 	
 	public boolean plan(String mapFilename, double mapResolution, double robotRadius, double startX, double startY, double startTheta, double goalX, double goalY, double goalTheta, PointerByReference path, IntByReference pathLength, double distanceBetweenPathPoints, double turningRadius);
 
-	public boolean plan_multiple_circles(String mapFilename, double mapResolution, double robotRadius, double[] xCoords, double[] yCoords, int numCoords, double startX, double startY, double startTheta, double goalX, double goalY, double goalTheta, PointerByReference path, IntByReference pathLength, double distanceBetweenPathPoints, double turningRadius, int plannerType, String experienceDBName, boolean forceUseRRTConnect);
+	public boolean plan_multiple_circles(String mapFilename, double mapResolution, double robotRadius, double[] xCoords, double[] yCoords, int numCoords, double startX, double startY, double startTheta, double goalX, double goalY, double goalTheta, PointerByReference path, IntByReference pathLength, double distanceBetweenPathPoints, double turningRadius, int plannerType, String experienceDBName, boolean isReplan);
 	
-	public boolean plan_multiple_circles_nomap(double[] xCoords, double[] yCoords, int numCoords, double startX, double startY, double startTheta, double goalX, double goalY, double goalTheta, PointerByReference path, IntByReference pathLength, double distanceBetweenPathPoints, double turningRadius, int plannerType, boolean forceUseRRTConnect);
+	public boolean plan_multiple_circles_nomap(double[] xCoords, double[] yCoords, int numCoords, double startX, double startY, double startTheta, double goalX, double goalY, double goalTheta, PointerByReference path, IntByReference pathLength, double distanceBetweenPathPoints, double turningRadius, int plannerType, boolean isReplan);
 
 	public void cleanupPath(Pointer p);
 	


### PR DESCRIPTION
This PR solves #10 

With this change, Only RRT-Connect planner will be used for replanning of paths in case of deadlocks. We disable planning from recall. However, the new alternate paths found using RRTConnect are added to the database of paths.